### PR TITLE
The connection url is expected to end with a slash

### DIFF
--- a/bin/run-database.sh
+++ b/bin/run-database.sh
@@ -91,7 +91,7 @@ elif [[ "$1" == "--connection-url" ]]; then
     {
       "type": "elasticsearch",
       "default": true,
-      "connection_url": "${ES_PROTOCOL}://${USERNAME:-aptible}:${PASSPHRASE}@${EXPOSE_HOST}:${!ES_EXPOSE_PORT_PTR}"
+      "connection_url": "${ES_PROTOCOL}://${USERNAME:-aptible}:${PASSPHRASE}@${EXPOSE_HOST}:${!ES_EXPOSE_PORT_PTR}/"
     }
   ]
 }

--- a/test/elasticsearch-all.bats
+++ b/test/elasticsearch-all.bats
@@ -167,7 +167,7 @@ export_exposed_ports() {
   URL="$(python -c "import sys, json; print json.load(open('url'))['credentials'][0]['connection_url']")"
   popd
 
-  [[ "https://aptible:password@localhost:443" = "$URL" ]]
+  [[ "https://aptible:password@localhost:443/" = "$URL" ]]
 
   run curl -k --fail "$URL"
 }


### PR DESCRIPTION
The original URL ended with a `/` (see [here](https://github.com/aptible/sweetness/pull/1159/files#diff-1797da80159c428aba725bbf987224cbaa17e634a1694097edfce5b60451592eL6)).

Sorry I missed this when I was looking into integration test failures last week.